### PR TITLE
Fixed mistyped header path for symbol table

### DIFF
--- a/src/lib/symbol_table.c
+++ b/src/lib/symbol_table.c
@@ -2,4 +2,4 @@
 // Created by hrs on 26/06/24.
 //
 
-#include "symbol_table.h"
+#include "headers/symbol_table.h"


### PR DESCRIPTION
This was messing with rvmcalc.